### PR TITLE
Fix generate table in update task. Improovment recreate snapshot

### DIFF
--- a/pve-zfs-clone
+++ b/pve-zfs-clone
@@ -3,6 +3,9 @@ error () {
 	if [[ $1 = snapshot ]]
 	then
 		echo 'Ошибка при создании снапшота'
+	elif [[ $1 = snapshot_destroy ]]
+	then
+		echo 'Ошибка при удалении снапшота'
 	elif [[ $1 = zfsclone ]]
 	then
 		echo 'Ошибка при создании клона из снапшота'
@@ -92,7 +95,8 @@ then
 	# Получаем список клонированных файловых систем
 	table=$(join \
 		<(sort <(pct list | tail -n +2 | awk '{print $1, "pct", $2, $3}' ; qm list | tail -n +2 | awk '{print $1, "qm", $3, $2}')) \
-		<(sort <(zfs list -H -o name,origin | awk '$2 != "-"' | awk 'match($1, /-[0-9][0-9][0-9]-disk/) { print substr($1, RSTART+1, 3), $0, substr($2, RSTART+1, 3)}')))
+		<(sort <(zfs list -H -o name,origin | awk '$2 != "-"' | awk 'match($1, /-[0-9][0-9][0-9]-disk/) { print substr($1, RSTART+1, 3), $0}' \
+			|  awk 'match($3, /-[0-9][0-9][0-9]-disk/) { print $0, substr($3, RSTART+1, 3)}')))
 	#echo "table" #debug
 	#echo "$table" #debug	
 	
@@ -136,21 +140,19 @@ then
 				echo -e "\033[0m\n\033[0m\033[31mВероятно файловая система имеет дочерние клоны, см. ошибку в консоли\033[0m"
 				exit
 			fi
-			#echo "$table" | awk "\$5 == \"${zfs}\""
 			
-			# destroy snap origin
+			VMID_origin=$(echo "$table" | awk "\$5 == \"${zfs}\"" | awk '{print $7}')
 			zfs_snap_origin=$(echo "$table" | awk "\$5 == \"${zfs}\"" | awk '{print $6}')
-			#echo "zfs_snap_origin: $zfs_snap_origin" #debug
-			zfs destroy -r $zfs_snap_origin
-			exitstatus=$?
-			if [ $exitstatus -ne 0 ]; then
-				whiptail --title  "Ошибка" --msgbox  "Вероятно снимок имеет дочерние клоны, см. ошибку в консоли" 10 60
-				echo -e "\033[0m\n\033[0m\033[31mВероятно снимок имеет дочерние клоны, см. ошибку в консоли\033[0m"
-				exit
+			
+			# re-create snapshot on origin
+			if [ "$($type listsnapshot $VMID_origin 2> /dev/null | grep VMID$LXC)" ]; then
+				$type delsnapshot $VMID_origin VMID$LXC || error snapshot_destroy
+				$type snapshot $VMID_origin VMID$LXC || error snapshot
+			else
+				zfs destroy -r $zfs_snap_origin || error snapshot_destroy
+				zfs snapshot $zfs_snap_origin || error snapshot
 			fi
 			
-			#create new zfs origin snapshot and clone
-			zfs snapshot $zfs_snap_origin
 			zfs clone $zfs_snap_origin $zfs
 		done < <(echo "$zfs_clone_list")
 		


### PR DESCRIPTION
Fix generate table in update task: 
It has index missmatch for clone in another root then origin.

 Improovment recreate snapshot: use pct\qm instead zfs if it possible